### PR TITLE
Removed unnecessary SASS Gems, since latest versions of Jekyll already support it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source 'https://rubygems.org'
-gem "jekyll-sass"
 gem "slim"
-gem "sass"

--- a/assets/css/styles.sass
+++ b/assets/css/styles.sass
@@ -1,2 +1,8 @@
+---
+---
+// Jekyll needs these triple dashes
+// to recognize files it has to process
+
 .content
   margin-top: 50px
+


### PR DESCRIPTION
As commented on #2
